### PR TITLE
Update example Makefile to support different bash locations

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,7 +15,7 @@ HERE=$(shell echo $$PWD)
 
 # Set bash instead of sh for the @if [[ conditions,
 # and use the usual safety flags:
-SHELL = /bin/bash -Eeu
+SHELL := $(shell which bash) -Eeu
 
 # The Lein profiles that will be selected for `lein-repl`.
 # Feel free to upgrade this, or to override it with an env var named LEIN_PROFILES.


### PR DESCRIPTION
On NixOS `/bin/bash` doesn't exist. This PR changes the example Makefile to use `which` to pull the path to bash from the PATH.